### PR TITLE
Open badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^8.2.0",
     "firebase-admin": "^9.5.0",
     "firebase-functions": "^3.13.2",
+    "joi": "^17.4.0",
     "nodemailer": "^6.5.0"
   },
   "devDependencies": {

--- a/src/badges/assertion.js
+++ b/src/badges/assertion.js
@@ -1,0 +1,86 @@
+const Joi = require('joi');
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const saltedHash = require('../utils/hash');
+
+const schema = Joi.object({
+  receiverId: Joi.string().trim().min(1),
+  badgeId: Joi.string().trim().min(1)
+});
+
+const buildAssertion = async ({ receiverId, issuedOn, ...rest }) => {
+  const receiver = (
+    await admin.firestore().collection('Participants').doc(receiverId).get()
+  ).data();
+  const { hash: identity, salt } = saltedHash(receiver.email);
+
+  return {
+    '@context': 'https://w3id.org/openbadges/v2',
+    type: 'Assertion',
+    issuedOn,
+    recipient: {
+      hashed: true,
+      type: 'email',
+      identity,
+      salt
+    },
+    verification: { type: 'HostedBadge' },
+    ...rest
+  };
+};
+
+exports.createAssertion = async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated');
+  }
+
+  const {
+    error,
+    params: { receiverId, badgeId }
+  } = schema.validate(data);
+
+  if (error) throw new functions.https.HttpsError('invalid-argument');
+
+  try {
+    const participant = await admin.firestore().collection('Participants').doc(receiverId).get();
+    const badge = await admin.firestore().collection('Badges').doc(badgeId).get();
+
+    if (!participant.exists || !badge.exists)
+      throw new functions.https.HttpsError('invalid-argument');
+
+    if (badge.data().issuerId !== context.auth.uid)
+      throw new functions.https.HttpsError('permission-denied');
+
+    admin
+      .firestore()
+      .collection('Assertions')
+      .doc()
+      .set({ receiverId, badgeId, issuedOn: new Date() });
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+};
+
+/**
+ * Retrieves an assertion.
+ */
+exports.getAssertion = async ({ id }) => {
+  try {
+    let assertion = await admin.firestore().collection('Assertions').doc(id).get();
+    if (!assertion.exists) throw new functions.https.HttpsError('not-found');
+
+    assertion = assertion.data();
+    const { badgeId } = assertion;
+    delete assertion.badgeId;
+
+    return buildAssertion({
+      ...assertion,
+      id: `${functions.config().frontend.url}api/assertions/${id}`,
+      badge: `${functions.config().frontend.url}api/badges/${badgeId}`
+    });
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/badges/assertion.js
+++ b/src/badges/assertion.js
@@ -26,7 +26,7 @@ const buildAssertion = async ({
   receiverId,
   issuedOn,
   feat,
-  issuer: { institute, website },
+  issuer: { institution, website },
   ...rest
 }) => {
   const receiver = (
@@ -49,7 +49,7 @@ const buildAssertion = async ({
       }/${feat.evidence}`,
       narrative: `Awarded for completing a ${
         feat.type === TYPES.learningOpportunity
-          ? `learning opportunity provided by ${institute}${
+          ? `learning opportunity provided by ${institution}${
               website ? `. More on us: ${website}` : ''
             }`
           : 'quest'

--- a/src/badges/assertion.js
+++ b/src/badges/assertion.js
@@ -26,7 +26,7 @@ const buildAssertion = async ({
   receiverId,
   issuedOn,
   feat,
-  issuer: { institution, website },
+  issuer: { institution, url },
   ...rest
 }) => {
   const receiver = (
@@ -50,7 +50,7 @@ const buildAssertion = async ({
       narrative: `Awarded for completing a ${
         feat.type === TYPES.learningOpportunity
           ? `learning opportunity provided by ${institution}${
-              website ? `. More on us: ${website}` : ''
+              url ? `. More on us: ${url}` : ''
             }`
           : 'quest'
       }.`

--- a/src/badges/badge.js
+++ b/src/badges/badge.js
@@ -1,0 +1,75 @@
+const Joi = require('joi');
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+const schema = Joi.object({
+  name: Joi.string().trim().min(1),
+  description: Joi.string().trim().min(1),
+  criteria: Joi.string().trim().min(1),
+  issuerId: Joi.string().trim().min(1),
+  image: Joi.string()
+    .trim()
+    .min(1)
+    .uri({ domain: { minDomainSegments: 2 } })
+});
+
+const buildBadgeClass = async ({ criteria, ...rest }) => {
+  return {
+    '@context': 'https://w3id.org/openbadges/v2',
+    type: 'BadgeClass',
+    criteria: {
+      narrative: criteria
+    },
+    ...rest
+  };
+};
+
+exports.createBadgeClass = async (data, context) => {
+  if (!context.auth) {
+    // TODO check that this user is an admin
+    throw new functions.https.HttpsError('unauthenticated');
+  }
+
+  const {
+    error,
+    params: { name, description, issuerId, criteria, image }
+  } = schema.validate(data);
+
+  if (error) throw new functions.https.HttpsError('invalid-argument');
+
+  try {
+    const issuer = await admin.firestore().collection('Participants').doc(issuerId).get();
+
+    if (!issuer.exists) throw new functions.https.HttpsError('invalid-argument');
+    if (!issuer.data().validated) throw new functions.https.HttpsError('permission-denied');
+
+    admin
+      .firestore()
+      .collection('Badges')
+      .doc()
+      .set({ name, description, issuerId, criteria, image });
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+};
+
+exports.getBadge = async ({ id }) => {
+  try {
+    let badge = await admin.firestore().collection('Badges').doc(id).get();
+    if (!badge.exists) throw new functions.https.HttpsError('not-found');
+
+    badge = badge.data();
+    const { issuerId } = badge;
+    delete badge.badgeId;
+
+    return buildBadgeClass({
+      ...badge,
+      id: `${functions.config().frontend.url}api/badges/${id}`,
+      issuer: `${functions.config().frontend.url}api/issuers/${issuerId}`
+    });
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/badges/badge.js
+++ b/src/badges/badge.js
@@ -38,7 +38,7 @@ exports.createBadgeClass = async (data, context) => {
   if (error) throw new functions.https.HttpsError('invalid-argument');
 
   try {
-    const issuer = await admin.firestore().collection('Participants').doc(issuerId).get();
+    const issuer = await admin.firestore().collection('Issuers').doc(issuerId).get();
 
     if (!issuer.exists) throw new functions.https.HttpsError('invalid-argument');
     if (!issuer.data().validated) throw new functions.https.HttpsError('permission-denied');
@@ -60,13 +60,12 @@ exports.getBadge = async ({ id }) => {
     if (!badge.exists) throw new functions.https.HttpsError('not-found');
 
     badge = badge.data();
-    const { issuerId } = badge;
     delete badge.badgeId;
 
     return buildBadgeClass({
       ...badge,
       id: `${functions.config().frontend.url}api/badges/${id}`,
-      issuer: `${functions.config().frontend.url}api/issuers/${issuerId}`
+      issuer: `${functions.config().frontend.url}api/issuers/gentlestudent`
     });
   } catch (error) {
     console.log(error);

--- a/src/badges/index.js
+++ b/src/badges/index.js
@@ -1,0 +1,5 @@
+const { createAssertion, getAssertion } = require('./assertion');
+const { createBadgeClass, getBadge } = require('./badge');
+const { getIssuer } = require('./issuer');
+
+module.exports = { createAssertion, getAssertion, createBadgeClass, getBadge, getIssuer };

--- a/src/badges/issuer.js
+++ b/src/badges/issuer.js
@@ -1,0 +1,30 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+const buildIssuer = async ({ criteria, ...rest }) => {
+  return {
+    '@context': 'https://w3id.org/openbadges/v2',
+    type: 'Issuer',
+    ...rest
+  };
+};
+
+exports.getIssuer = async ({ id }) => {
+  try {
+    const issuer = await admin.firestore().collection('Issuers').doc(id).get();
+    if (!issuer.exists) throw new functions.https.HttpsError('not-found');
+
+    const { name, email, institution, phonenumber, url } = issuer.data();
+
+    return buildIssuer({
+      name,
+      email,
+      url,
+      description: `Institution: ${institution} - Email: ${email} - Phone: ${phonenumber}`,
+      id: `${functions.config().frontend.url}api/issuers/${id}`
+    });
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/badges/issuer.js
+++ b/src/badges/issuer.js
@@ -1,4 +1,3 @@
-const admin = require('firebase-admin');
 const functions = require('firebase-functions');
 
 const buildIssuer = async ({ criteria, ...rest }) => {
@@ -9,19 +8,13 @@ const buildIssuer = async ({ criteria, ...rest }) => {
   };
 };
 
-exports.getIssuer = async ({ id }) => {
+exports.getIssuer = async () => {
   try {
-    const issuer = await admin.firestore().collection('Issuers').doc(id).get();
-    if (!issuer.exists) throw new functions.https.HttpsError('not-found');
-
-    const { name, email, institution, phonenumber, url } = issuer.data();
-
     return buildIssuer({
-      name,
-      email,
-      url,
-      description: `Institution: ${institution} - Email: ${email} - Phone: ${phonenumber}`,
-      id: `${functions.config().frontend.url}api/issuers/${id}`
+      name: 'Gentlestudent',
+      email: functions.config().mailer.email,
+      url: functions.config().frontend.url,
+      id: `${functions.config().frontend.url}api/issuers/gentlestudent`
     });
   } catch (error) {
     console.log(error);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
 const admin = require('firebase-admin');
 const functions = require('firebase-functions');
 const { createParticipant, resetPassword, changeEmail } = require('./auth');
+const {
+  createAssertion,
+  getAssertion,
+  createBadgeClass,
+  getBadge,
+  getIssuer
+} = require('./badges');
 
 admin.initializeApp();
 
 exports.createParticipant = functions.https.onCall(createParticipant);
 exports.resetPassword = functions.https.onCall(resetPassword);
 exports.changeEmail = functions.https.onCall(changeEmail);
+exports.createAssertion = functions.https.onCall(createAssertion);
+exports.getAssertion = functions.https.onCall(getAssertion);
+exports.createBadgeClass = functions.https.onCall(createBadgeClass);
+exports.getBadge = functions.https.onCall(getBadge);
+exports.getIssuer = functions.https.onCall(getIssuer);

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,0 +1,8 @@
+const crypto = require('crypto');
+
+module.exports = function saltedHash(value) {
+  const sum = crypto.createHash('sha256');
+  const salt = crypto.randomBytes(16).toString('hex');
+  sum.update(value + salt);
+  return { hash: `sha256$${sum.digest('hex')}`, salt };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,6 +961,18 @@
     lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
 
+"@hapi/hoek@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
+  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -1013,6 +1025,23 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@sideway/address@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d"
+  integrity sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2477,6 +2506,17 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+joi@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Closes #5 
Closes #4 

**BadgeClass**

Idea is to only store a badge info once. But unless we make `description` and `criteria` static (then they would not match the ones on an opportunity), we can only confidently store the `name` and `image` of a badge.

_Current implementation:_
To create a badge, user is asked for the name and image of the badge.
The badge is dynamically created on each get request by getting all missing information using the opportunity.

_Drawbacks:_
Each endpoint hit costs 2 reads

This drawback may be solved by
- storing on each opportunity the static data of a the badge (i.e. name and image)
- creating a new badge document for each opportunity
- caching

_Advantages:_
Kind on storage space

**Assertion**

An assertion is created by storing essentially `opportunityId` and `receiverId` (the participant id). The JSON is built dynamically, so that all the information is up to date (about the issuer, whose organisation name and website url are added to the narrative field, and the participant email).

_Drawbacks:_
Each endpoint hit costs 4 reads

This drawback may be solved by
- removing the dynamic feature and store all info once
- caching

_Advantages:_
Updated data

**Issuer**

The only issuer is Gentlestudent and all data is static, configurable using Cloud Functions environment.